### PR TITLE
Minor README fix - the directory is doc not docs

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -9,7 +9,7 @@ which aims to track government finance around the world.
 
 ## Developer installation
 
-Please see docs/install.rst or http://docs.openspending.org/en/latest/install.html.
+Please see doc/install.rst or http://docs.openspending.org/en/latest/install.html.
 
 ## Issue tracking
 


### PR DESCRIPTION
Minor cosmetic fix - `README.mkd` refers to `docs/install.rst`, should be `doc/install.rst`
