### PR TITLE
Add frame as part of all embeds with OKF/OpenSpending logo/text Edit

### DIFF
--- a/openspending/ui/templates/view/embed.html
+++ b/openspending/ui/templates/view/embed.html
@@ -40,6 +40,7 @@
           bottom:0;
           right:0;
           color: #333;
+          text-decoration: underline;
           background-color: #fff;
           background-color: rgba(255, 255, 255, 0.8);
           padding: 0 3px;
@@ -61,7 +62,7 @@
 
     ${script_boot()}
     ${widget_js('widget', c.widget, c.state, handles=False, embed=True)}
-    <a id="credit" href="http://www.openspending.org/">Powered by OpenSpending</a>
+    <a id="credit" href="http://www.openspending.org/">Visualised with OpenSpending</a>
     ${analytics()}
   </body>
 </html>


### PR DESCRIPTION
When users embed their visualisation on their own site, it should be clear that it was developed at OpenSpending.
