### PR TITLE
Move the mailing list subscription box to homepage (Fixes #560)

### DIFF
--- a/openspending/ui/templates/home/index.html
+++ b/openspending/ui/templates/home/index.html
@@ -61,6 +61,15 @@
         <a href="/blog/atom.xml"><img src="/blog/images/blog_feed.png" /></a>
       </div>
 
+      <div class="caption">
+        <h3>Join our discussion list!</h3>
+        <form action="http://lists.okfn.org/mailman/subscribe/openspending"
+          method="POST" class="form-inline">
+          <input type="text" class="input-medium" name="email" placeholder="Email" />
+          <button type="submit" class="btn">Sign up</button>
+        </form>
+      </div>
+
     </div>
   </div>
   <div class="row">&nbsp;</div>


### PR DESCRIPTION
I've just created a mailing list signup box on the frontpage.

![sidebar](https://f.cloud.github.com/assets/373438/296424/7853e7fe-94f7-11e2-9fb5-283c4e479262.png)

@anderspeders Let me know if this looks good to you.

Fixes #560 
