### PR TITLE
[#545] Create a public profile page and link it up

### DIFF
--- a/openspending/ui/config/routing.py
+++ b/openspending/ui/config/routing.py
@@ -38,6 +38,7 @@ def make_map():
     map.connect('/after_logout', controller='account', action='after_logout')
     map.connect('/account/forgotten', controller='account', action='trigger_reset')
     map.connect('/account/reset', controller='account', action='do_reset')
+    map.connect('/account/profile/{name}', controller='account', action='profile')
 
     map.connect('/blog/*path', controller='content', action='view', section='blog')
     map.connect('/blog', controller='content', action='view', section='blog',

--- a/openspending/ui/controllers/account.py
+++ b/openspending/ui/controllers/account.py
@@ -184,3 +184,12 @@ class AccountController(BaseController):
             + "your password!"))
         redirect(h.url_for(controller='account', action='settings'))
 
+    def profile(self, name=None):
+        c.config = config
+        account = Account.by_name(name)
+        if account is None:
+            response.status = 404
+            return None
+        c.profile = account
+        c.is_admin = True if (c.account and c.account.admin is True) else False
+        return render('account/profile.html')

--- a/openspending/ui/templates/account/profile.html
+++ b/openspending/ui/templates/account/profile.html
@@ -1,0 +1,34 @@
+<html xmlns:py="http://genshi.edgewall.org/"
+  xmlns:i18n="http://genshi.edgewall.org/i18n"
+  xmlns:xi="http://www.w3.org/2001/XInclude" py:strip="">
+
+  <py:def function="nav_class">nav-account</py:def>
+
+  <py:def function="page_title" i18n:msg="name">${c.profile['fullname']}</py:def>
+
+  <div py:def="content">
+    <h2 class="page-header">${c.profile.fullname}
+    </h2>
+
+    <div class="row">
+      <div class="offset2 span10">
+        <dl class="dl-horizontal">
+          <py:if test="c.profile.fullname">
+            <dt>Name</dt>
+            <dd>${c.profile.fullname}</dd>
+          </py:if>
+          <dt>Username</dt>
+          <dd>${c.profile.name}</dd>
+          <py:if test="hasattr(c, 'is_admin') and c.is_admin">
+            <dt>Email</dt>
+            <dd>${c.profile.email}</dd>
+          </py:if>
+        </dl>
+      </div>
+    </div>
+
+  </div>
+
+  <xi:include href="../layout.html" />
+</html>
+

--- a/openspending/ui/templates/dataset/about.html
+++ b/openspending/ui/templates/dataset/about.html
@@ -2,10 +2,10 @@
   xmlns:i18n="http://genshi.edgewall.org/i18n"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   py:strip="">
-  
+
   <xi:include href="_nav.html" />
   <xi:include href="../dimension/_list.html" />
-  
+
   <py:def function="nav_class">nav-dataset</py:def>
 
   <py:def function="page_title">${c.dataset.label or c.dataset.name}</py:def>
@@ -38,8 +38,8 @@
             <h3>Sources</h3>
             <span class="help-block" i18n:msg="">
               This is a listing of all source data that was registered
-              for this dataset. If you want to look at the exact data 
-              that is used to generate aggregates, you can also use a 
+              for this dataset. If you want to look at the exact data
+              that is used to generate aggregates, you can also use a
               <a href="${h.url(controller='content', action='view',
                 section='help', path='api-search.html')}">bulk export</a>.
             </span>
@@ -59,7 +59,8 @@
             </span>
             <br/>
             <ul py:if="len(c.managers)">
-              <li py:for="account in c.managers">${account.display_name}</li>
+              <li py:for="account in c.managers"><a
+                href="${url(controller='account', action='profile', name=account.name)}">${account.display_name}</a></li>
             </ul>
           </div>
         </div>
@@ -67,7 +68,7 @@
       <div class="span4">
         <h3>Measures</h3>
         <span class="help-block">
-          Measures are the numeric properties of each entry in this 
+          Measures are the numeric properties of each entry in this
           dataset.
         </span>
         <ul>

--- a/openspending/ui/test/functional/test_dataset.py
+++ b/openspending/ui/test/functional/test_dataset.py
@@ -11,8 +11,8 @@ class TestDatasetController(ControllerTestCase):
     def setup(self):
 
         super(TestDatasetController, self).setup()
-        h.load_fixture('cra')
-        h.make_account('test')
+        self.dataset = h.load_fixture('cra')
+        self.user = h.make_account('test')
         h.clean_and_reindex_solr()
 
     def test_index(self):
@@ -68,6 +68,15 @@ class TestDatasetController(ControllerTestCase):
 
         h.assert_true(url_ in response,
                       "Link to view page (JSON format) not in response!")
+
+    def test_about_has_profile_links(self):
+        self.dataset.managers.append(self.user)
+        db.session.add(self.dataset)
+        db.session.commit()
+        response = self.app.get(url(controller='dataset', action='about',
+                                dataset='cra'))
+        assert ('<li><a href="/account/profile/test">Test User</a></li>' in
+                response.body)
 
     def test_view_json(self):
         response = self.app.get(url(controller='dataset', action='view',


### PR DESCRIPTION
- Create a public profile page. It currently lists only username and full name.
- Link it from the About page of the dataset.
- Admins can see email on profile page.
