### PR TITLE
Template root directory is loaded based on file position

### DIFF
--- a/openspending/ui/alttemplates/templating.py
+++ b/openspending/ui/alttemplates/templating.py
@@ -13,7 +13,7 @@ import lxml.html
 from lxml.html import builder as E
 
 # Set the directory where this file is as the template root directory
-template_rootdir = os.path.dirname(__file__)
+template_rootdir = os.path.abspath(os.path.dirname(__file__))
 
 def languages(detected_languages, current_language):
     def lang_triple(lang):


### PR DESCRIPTION
Jinja2 template root directory is loaded based on where the templating.py file is located, not from a hardcoded value that requires openspending to be started in a specific directory. Fixes #597 
