### PR TITLE
Added a jquery cookie script loader in old template layout

### DIFF
--- a/openspending/ui/templates/layout.html
+++ b/openspending/ui/templates/layout.html
@@ -179,6 +179,7 @@
 
     ${analytics()}
 
+  <script src="${h.static('js/jquery.cookie.js')}"></script>
   <script type="text/javascript">
     jQuery(document).ready(function() {
       if($.cookie("cookiecheck")) {


### PR DESCRIPTION
Fixes #607 - a bug (related to jinja2 move) where the newer templates had the jquery cookie script but the older ones didn't. 
