### PR TITLE
Removed datasets from the params

### DIFF
--- a/openspending/ui/controllers/api/version2.py
+++ b/openspending/ui/controllers/api/version2.py
@@ -142,11 +142,6 @@ class APIv2Controller(BaseController):
         if not datasets:
             return {'errors': ["No dataset available."]}
 
-        params['filter']['dataset'] = []
-        for dataset in datasets:
-            require.dataset.read(dataset)
-            params['filter']['dataset'].append(dataset.name)
-
         response.last_modified = max([d.updated_at for d in datasets])
         etag_cache_keygen(parser.key(), response.last_modified)
 


### PR DESCRIPTION
Datasets list in params will get changed into X-Filter header which is can get too long for proxies, varnish etc.
Also since X- headers are deprecated: http://tools.ietf.org/html/rfc6648 we should move away from using these headers

Fixes #714 (it stops on varnish because of this header)
