### PR TITLE
Added error message (code: 400) when json model cannot be parsed

### DIFF
--- a/openspending/ui/controllers/api/version2.py
+++ b/openspending/ui/controllers/api/version2.py
@@ -226,7 +226,10 @@ class APIv2Controller(BaseController):
             else abort(status_code=400, detail='csv_file is missing')
 
         # We proceed with the dataset
-        model = json.load(urllib2.urlopen(metadata))
+        try:
+            model = json.load(urllib2.urlopen(metadata))
+        except:
+            abort(status_code=400, detail='JSON model could not be parsed')
         try:
             log.info("Validating model")
             model = validate_model(model)


### PR DESCRIPTION
When a user submits a dataset via the api and the model cannot be parsed openspending just fails and gives a 500 error. This catches that error and gives the user an error message.

Fixes #727 
