### PR TITLE
Support Vagrant for developer mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ openspendingjs
 solr
 *~
 .tx/config
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,16 @@
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "raring64"
+  config.vm.box_url = "http://goo.gl/ceHWg"
+  config.vm.hostname = "openspending"
+  config.cache.auto_detect = true
+  config.vm.network :forwarded_port, guest: 5000, host: 5000
+  config.vm.network :forwarded_port, guest: 8080, host: 8080
+
+  # config.vm.provider :virtualbox do |vb|
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "2048"]
+  # end
+
+  config.vm.provision :shell, :privileged => false, :path => 'bin/vagrant_deploy'
+end

--- a/bin/vagrant_deploy
+++ b/bin/vagrant_deploy
@@ -1,0 +1,44 @@
+
+sudo apt-get update -y
+sudo apt-get install python g++ make
+sudo apt-get install -y python-lxml libxml2-dev libxslt1-dev postgresql-9.1 python-virtualenv git postgresql-server-dev-9.1 postgresql-client-9.1 postgresql-contrib-9.1 python-dev tomcat7 rabbitmq-server
+
+wget -O /tmp/solr.tgz http://archive.apache.org/dist/lucene/solr/4.6.0/solr-4.6.0.tgz
+cd /tmp
+tar xvfz /tmp/solr.tgz 
+sudo mv solr-4.6.0 /var/solr
+sudo cp /var/solr/dist/solr-4.6.0.war /var/lib/tomcat7/webapps/solr.war
+sudo cp -R /var/solr/example/solr /var/solr/home
+sudo mv /var/solr/home/collection1 /var/solr/home/openspending
+sudo chown -R tomcat7.tomcat7 /var/solr/home
+echo "name=openspending" | sudo tee /var/solr/home/openspending/core.properties
+
+sudo mkdir /var/lib/tomcat7/lib
+sudo cp /var/solr/dist/solrj-lib/* /var/lib/tomcat7/lib
+sudo cp /vagrant/solr/openspending_schema.xml /var/solr/home/openspending/conf/schema.xml
+
+echo -en "\n\nJAVA_OPTS=\"-Djava.awt.headless=true -Xmx512m -XX:+UseConcMarkSweepGC -Dsolr.solr.home=/var/solr/home\"\n" | sudo tee -a /etc/default/tomcat7
+sudo service tomcat7 restart
+
+virtualenv /home/vagrant/env
+source /home/vagrant/env/bin/activate
+pip install -r /vagrant/requirements.txt
+pip install -e /vagrant
+pip install psycopg2
+echo "source /home/vagrant/env/bin/activate" >>/home/vagrant/.profile
+
+sudo -u postgres createuser -s vagrant
+createdb -E utf-8 -O vagrant openspending
+psql -d openspending -c "ALTER USER vagrant PASSWORD 'vagrant';"
+
+cd /vagrant
+if [ ! -d /vagrant/openspendingjs ]
+then
+  git clone http://github.com/openspending/openspendingjs.git
+fi
+if [ ! -L /vagrant/openspending/ui/public/static/openspendingjs ]
+then
+  ln -s openspendingjs openspending/ui/public/static/openspendingjs
+fi
+
+ostool vagrant.ini db init

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -1,6 +1,25 @@
 Installation and Setup
 ======================
 
+
+Using Vagrant
+'''''''''''''
+
+You can avoid installing OpenSpending on your development machine by using Vagrant_ to execute the application and all of its dependencies in a virtual machine. To make use of this option, make sure to install Vagrant and the included VirtualBox provider. Then, from the source repository, you can set up a VM with::
+
+    $ vagrant up
+
+This will run for a while (fetch a coffee), until a working VM with Ubuntu 13.04 and OpenSpending has been deployed. Once the application has run, you can run OpenSpending within the VM::
+
+    $ vagrant ssh
+    vagrant@openspending$ cd /vagrant
+    vagrant@openspending$ paster serve --reload vagrant.ini 
+
+The virtual machine includes OpenSpending, Postgres, RabbitMQ and Solr.
+
+.. _Vagrant: http://vagrantup.com/
+
+
 Requirements
 '''''''''''''
 


### PR DESCRIPTION
During a recent discussion of the OS upload service, @rgrp stated that he refused to work on the Python codebase of OpenSpending because he found it too difficult to install. I've therefore created a Vagrantfile for OpenSpending which boils down the installation to a single command.

Hope this helps in re-considering the architecture decision which is the OS uploader. 
