### PR TITLE
Allow faking out the Inflation library

### DIFF
--- a/development.ini_tmpl
+++ b/development.ini_tmpl
@@ -85,6 +85,15 @@ openspending.content_root = http://content.openspending.org
 # Directory containing migration modules
 # openspending.migrate_dir = %(here)s/migration
 
+
+# ############################## #
+# OpenSpending debugging options #
+# ############################## # 
+
+# Use a fake inflation library (that simulates 0% inflation)
+# openspending.fake_inflation = false
+
+
 # ############# #
 # Celery config #
 # ############# # 

--- a/openspending/ui/lib/app_globals.py
+++ b/openspending/ui/lib/app_globals.py
@@ -27,4 +27,8 @@ class Globals(object):
         self.script_root = config.get('openspending.script_root', '/static/js')
         self.content_root = config['openspending.content_root']
 
-        self.inflation = Inflation()
+        if asbool(config.get('openspending.fake_inflation', False)):
+            from .fake_inflation import Inflation as FakeInflation
+            self.inflation = FakeInflation()
+        else:
+            self.inflation = Inflation()

--- a/openspending/ui/lib/fake_inflation.py
+++ b/openspending/ui/lib/fake_inflation.py
@@ -1,0 +1,13 @@
+import collections
+
+InflationResult = collections.namedtuple('Inflation', 'factor value')
+
+class Inflation(object):
+    def __init__(self, source=None, reference=None, country=None):
+        pass
+
+    def get(self, target=None, reference=None, country=None):
+        return InflationResult(factor=1.0, value=0.0)
+
+    def inflate(self, amount, target=None, reference=None, country=None):
+        return amount


### PR DESCRIPTION
The economics.inflation.Inflation() constructor makes a request to a remote URL, which means that it can't be used offline. Add an "openspending.fake_inflation" config variable which allows the use of a fake (unit) Inflation class for debugging and development purposes.
