### PR TITLE
Docker [WIP]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM orchardup/python:2.7
+MAINTAINER The OpenSpending Contributors
+
+# Install required headers
+RUN apt-get update -qq
+RUN apt-get install -y python-dev libpq-dev libxml2-dev libxslt1-dev
+
+# Install OpenSpending requirements
+RUN mkdir /src
+WORKDIR /src
+ADD requirements.txt /src/
+RUN pip install -r requirements.txt
+
+# Install OpenSpending itself from the current directory
+ADD . /src/
+RUN pip install -e .
+
+# Expose the web port
+EXPOSE 5000
+
+# Run development server by default
+ENV PYTHONUNBUFFERED 1
+CMD ["contrib/docker/envexec", "paster", "serve", "--reload", "contrib/docker/development.ini"]

--- a/contrib/docker/development.ini
+++ b/contrib/docker/development.ini
@@ -1,0 +1,143 @@
+#
+# openspending-ui - Pylons configuration
+#
+# The %(here)s variable will be replaced with the parent directory of this file
+#
+[DEFAULT]
+debug = true
+
+[server:main]
+use = egg:Paste#http
+host = 0.0.0.0
+port = 5000
+
+[app:main]
+use = egg:openspending
+full_stack = true
+static_files = true
+
+cache_dir = %(here)s/../../.pylons_data
+beaker.session.key = openspending.ui
+beaker.session.secret = ${app_instance_secret}
+app_instance_uuid = ${app_instance_uuid}
+
+# ################### #
+# OpenSpending config #
+# ################### #
+
+# i18n
+# lang = en
+
+# Default dataset
+# openspending.default_dataset = cra
+
+# Use celery for background jobs
+# openspending.use_celery = true
+
+# Numerous site-configurable strings
+# openspending.site_title = OpenSpending
+# openspending.site_slogan = Mapping the money.
+# openspending.site_logo = /images/datastore-logo.png
+# openspending.wiki_link = http://wiki.openspending.org/
+# openspending.blog_link = http://wheredoesmymoneygo.org/blog/
+# openspending.api_link = http://wiki.openspending.org/API
+# openspending.lists_link = http://lists.okfn.org/mailman/listinfo/openspending-discuss
+# openspending.forum_link =
+# openspending.subscribe_community = http://lists.okfn.org/mailman/subscribe/openspending
+# openspending.subscribe_developer = http://lists.okfn.org/mailman/subscribe/openspending-dev
+
+# In case Varnish or something similar messes with the HTTP headers we have
+# to provide a way to enforce the protocol somehow
+# openspending.enforced_protocol = 'https'
+
+# DATABASE_URL env var determines database location
+
+# SOLR_URL env var determines solr location
+
+# Plugins (space-delimited list)
+# openspending.plugins =
+
+# Widgets
+openspending.widgets_base = http://assets.openspending.org/widgets
+openspending.widgets = treemap bubbletree aggregate_table
+
+# Relative path to static files
+# openspending.static_path = /static
+
+# Upload directory
+# If the directory starts with '/' it is assumed to be an absolute path
+# if not it is assumed to be relative to pylon's static_file directory
+openspending.upload_directory = files
+
+# Where are uploads served from by web server
+# (leave commented out if pylons app should serve the uploaded files)
+# openspending.upload_uri = /files
+
+# JavaScript files root
+openspending.script_root = /static/openspendingjs
+openspending.content_root = http://content.openspending.org
+
+# Static file cache version
+# openspending.static_cache_version =
+
+# Directory containing migration modules
+openspending.migrate_dir = %(here)s/../../migration
+
+# Debug options
+openspending.fake_inflation = true
+
+# ############# #
+# Celery config #
+# ############# #
+
+# BROKER_URL env var determines broker location
+
+celery.imports = openspending.tasks
+
+celery.result.backend = amqp
+celery.result.dburi = amqp://
+celery.result.serializer = json
+
+celeryd.concurrency = 4
+#celeryd.log.file = celeryd.log
+celeryd.log.level = debug
+celeryd.max.tasks.per.child = 1
+
+#tasks will never be sent to the queue, but executed locally instead.
+#celery.always.eager = false
+
+# Logging configuration:
+#   http://wiki.pylonshq.com/display/pylonsdocs/Logging
+[loggers]
+keys = root, sqlalchemy, openspending
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_openspending]
+level = DEBUG
+handlers = console
+qualname = openspending
+propagate = 0
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/contrib/docker/envexec
+++ b/contrib/docker/envexec
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# This file is intended to be used as a wrapper for "paster serve..." when the
+# container is started. It will provide more helpful error messages than
+# OpenSpending itself if the required configuration environment variables are
+# not set.
+#
+#     envexec paster serve --reload development.ini
+#
+
+set -eu
+
+: $DATABASE_URL
+: $SOLR_URL
+: $BROKER_URL
+
+exec "$@"

--- a/openspending/ui/config/environment.py
+++ b/openspending/ui/config/environment.py
@@ -1,6 +1,8 @@
 """Pylons environment configuration"""
 import logging
 import os
+from os import environ as env
+import urlparse
 
 from pylons import config
 
@@ -34,6 +36,18 @@ def load_environment(global_conf, app_conf):
     config['routes.map'] = routing.make_map()
     config['pylons.app_globals'] = app_globals.Globals()
     config['pylons.h'] = helpers
+
+    # Import config from environment if present
+    if env.get('DATABASE_URL') is not None:
+        config['openspending.db.url'] = env.get('DATABASE_URL')
+    if env.get('SOLR_URL') is not None:
+        config['openspending.solr.url'] = env.get('SOLR_URL')
+    if env.get('BROKER_URL') is not None:
+        url = urlparse.urlparse(env.get('BROKER_URL'))
+        config['broker.host'] = url.hostname
+        config['broker.port'] = url.port
+        config['broker.user'] = url.username
+        config['broker.password'] = url.password
 
     # set log level in markdown
     markdown.logger.setLevel(logging.WARN)


### PR DESCRIPTION
*This branch is a work-in-progress, so this is PR is a placeholder for a conversation, not a request to merge.*

This adds a basic Dockerfile, currently tuned for use in development.

It would be nice to push binary images of OpenSpending, suitable for production usage, to the [public docker registry](https://index.docker.io/), allowing people to deploy OpenSpending with a command as simple as `docker run openspending/openspending`.

At the moment, this `Dockerfile` builds a development-friendly OpenSpending, that allows the mounting of the source directory at `/src`. Perhaps we should use `Dockerfile.dev` for development and put sane defaults for production in `Dockerfile`.

I've also wondered about including a [`fig.yml`](http://orchardup.github.io/fig/index.html) in the repository...

Thoughts? To be clear this currently duplicates some of the functionality of @pudo's Vagrantfile, but is somewhat more flexible in that it can be used both as part of a one-click development environment, *and* for deployment in production. Eventually I think we should standardise on one or the other approach to configuring a dev env.