### PR TITLE
Upgrade to SQLAlchemy 0.9.4

### DIFF
--- a/openspending/model/common.py
+++ b/openspending/model/common.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from json import dumps, loads
-from sqlalchemy.types import Text, MutableType, TypeDecorator
-
+from sqlalchemy.types import Text, TypeDecorator
+from sqlalchemy.ext.mutable import Mutable
 from openspending.model import meta as db
 
 ALIAS_PLACEHOLDER = u'‽'
@@ -33,7 +33,49 @@ def decode_row(row, dataset):
     return result
 
 
-class JSONType(MutableType, TypeDecorator):
+class MutableDict(Mutable, dict):
+
+    """
+    Create a mutable dictionary to track mutable values
+    and notify listeners upon change.
+    """
+
+    @classmethod
+    def coerce(cls, key, value):
+        """
+        Convert plain dictionaries to MutableDict
+        """
+
+        # If it isn't a MutableDict already we conver it
+        if not isinstance(value, MutableDict):
+            # If it is a dictionary we can convert it
+            if isinstance(value, dict):
+                return MutableDict(value)
+                
+            # Try to coerce but it will probably return a ValueError
+            return Mutable.coerce(key, value)
+        else:
+            # Since we already have a MutableDict we can just return it
+            return value
+
+    def __setitem__(self, key, value):
+        """
+        Set a value to a key and notify listeners of change
+        """
+
+        dict.__setitem__(self, key, value)
+        self.changed()
+
+    def __delitem__(self, key):
+        """
+        Delete a key and notify listeners of change
+        """
+
+        dict.__delitem__(self, key)
+        self.changed()
+
+
+class JSONType(TypeDecorator):
     impl = Text
 
     def __init__(self):

--- a/openspending/model/dataset.py
+++ b/openspending/model/dataset.py
@@ -16,7 +16,7 @@ from sqlalchemy import ForeignKeyConstraint
 from openspending.model import meta as db
 from openspending.lib.util import hash_values
 
-from openspending.model.common import TableHandler, JSONType, \
+from openspending.model.common import TableHandler, MutableDict, JSONType, \
     decode_row
 from openspending.model.dimension import CompoundDimension, \
     AttributeDimension, DateDimension
@@ -52,7 +52,7 @@ class Dataset(TableHandler, db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow,
                            onupdate=datetime.utcnow)
-    data = db.Column(JSONType, default=dict)
+    data = db.Column(MutableDict.as_mutable(JSONType), default=dict)
 
     languages = db.association_proxy('_languages', 'code')
     territories = db.association_proxy('_territories', 'code')

--- a/openspending/model/source.py
+++ b/openspending/model/source.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from openspending.model import meta as db
-from openspending.model.common import JSONType
+from openspending.model.common import MutableDict, JSONType
 from openspending.model.dataset import Dataset
 from openspending.model.account import Account
 
@@ -13,7 +13,7 @@ class Source(db.Model):
     url = db.Column(db.Unicode)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, onupdate=datetime.utcnow)
-    analysis = db.Column(JSONType, default=dict)
+    analysis = db.Column(MutableDict.as_mutable(JSONType), default=dict)
 
     dataset_id = db.Column(db.Integer, db.ForeignKey('dataset.id'))
     dataset = db.relationship(Dataset,

--- a/openspending/model/view.py
+++ b/openspending/model/view.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from openspending.model import meta as db
 from openspending.model.dataset import Dataset
 from openspending.model.account import Account
-from openspending.model.common import JSONType
+from openspending.model.common import MutableDict, JSONType
 
 
 class View(db.Model):
@@ -16,7 +16,7 @@ class View(db.Model):
     name = db.Column(db.Unicode(2000))
     label = db.Column(db.Unicode(2000))
     description = db.Column(db.Unicode())
-    state = db.Column(JSONType, default=dict)
+    state = db.Column(MutableDict.as_mutable(JSONType), default=dict)
     public = db.Column(db.Boolean, default=False)
 
     created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ PasteScript==1.7.5
 Pygments==1.5
 Pylons==1.0
 Routes==1.13
-SQLAlchemy==0.7.2
+SQLAlchemy==0.9.4
 Sphinx>=1.2b
 Tempita==0.5.1
 Unidecode==0.04.9
@@ -49,7 +49,7 @@ requests==0.12.1
 rsa==3.1.1
 simplejson==2.6.0
 solrpy==0.9.4
-sqlalchemy-migrate==0.7.1
+sqlalchemy-migrate==0.9
 translationstring==1.1
 xlrd==0.7.1
 zope.interface==4.0.1


### PR DESCRIPTION
Inefficiencies in MutableType means we should switch over to
sqlalchemy.ext.mutable to create listeners for mutable types. This
was already recommended in sqlalchemy 0.7 (our previous version)
but the inefficiency was removed in 0.8. We therefore need to
change our code for this upgrade and move to the more efficient
sqlalchemy.ext.mutable

This also requires an upgrade of sqlalchemy-migrate because the old
version used sqlalchemy.exceptions which is now called sqlalchemy.exc
