### PR TITLE
Vagrant link was dead - new working link to a raring64 box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,8 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "raring64"
-  config.vm.box_url = "http://goo.gl/ceHWg"
+  config.vm.box_url = "https://vagrantcloud.com/larryli/raring64/version/4/provider/virtualbox.box"
+# config.vm.box_url = "https://vagrantcloud.com/ubuntu/trusty64/version/1/provider/virtualbox.box"
   config.vm.hostname = "openspending"
   config.cache.auto_detect = true
   config.vm.network :forwarded_port, guest: 5000, host: 5000


### PR DESCRIPTION
- link is: https://vagrantcloud.com/larryli/raring64/version/4/provider/virtualbox.box
