### PR TITLE
Grammer Fixes in View Form

### DIFF
--- a/openspending/ui/alttemplates/view/view.html
+++ b/openspending/ui/alttemplates/view/view.html
@@ -35,11 +35,11 @@
 <p>
   <div class="help-block">
     {% trans %}Here you can rename your widget and/or update the description.
-    You can also change and modify the the widget itself but keep in
-    mind that others might be using and embedding the widget as it is
-    now on their sites. <strong>Changing the widget here will change
-    it everywhere.</strong> This might then create a discrepancy
-    between the widget and the context of a page it's embedded in.{% endtrans %}
+    You can also modify the widget itself, but keep in mind that others might be 
+    using and embedding the widget as it is now on their sites. 
+    <strong>Changing the widget here will change it everywhere.</strong> 
+    This might then create a discrepancy between the widget and the context of 
+    a page in which it's embedded.{% endtrans %}
   </div>
 </p>
 <p><button class="btn btn-large btn-success">{% trans %}Update widget{% endtrans %}</button></p>


### PR DESCRIPTION
Fixes issue #813

Removed the duplicate "the"s and reduced the redundant "change and modify" to
"modify", as mentioned in issue #813.

Also added a comma before "but" in the second sentence, as the conjunction
separates main clauses, and restructured the final sentence so that it does not
end with a preposition.
