### PR TITLE
make sure slashes are forward for windows machines from gettext module

### DIFF
--- a/openspending/ui/alttemplates/templating.py
+++ b/openspending/ui/alttemplates/templating.py
@@ -77,7 +77,7 @@ def postprocess_forms(s, form_errors):
     root = lxml.html.fromstring(s)
     processors = [input_errors, select_errors, textarea_errors]
     [process(root) for process in processors]
-    return lxml.html.tostring(root, doctype=root.getroottree().docinfo.doctype)
+    return lxml.html.tostring(root)
 
 
 def render(path, **kwargs):

--- a/openspending/ui/i18n/__init__.py
+++ b/openspending/ui/i18n/__init__.py
@@ -16,7 +16,8 @@ def get_available_languages():
     messagefiles = gettext.find(config['pylons.package'], localedir,
                                 languages=babel.Locale('en').languages.keys(),
                                 all=True)
-    return [path.split('/')[-3] for path in messagefiles]
+
+    return [path.split(os.path.sep)[-3] for path in messagefiles]
 
 
 def get_available_locales():


### PR DESCRIPTION
I was getting an error after install that templates could not read nonetype on paster serve.  Traced it to splitting the files with forward slash only.
Depending on the core contributors' preference, making sure there are forward slashes could be done a number of ways.  I just did the first approach that popped in my head.  os.name == 'nt' might be a more elegant solution.
