### PR TITLE
Get rid of sharethis.com button

### DIFF
--- a/openspending/ui/alttemplates/_util.html
+++ b/openspending/ui/alttemplates/_util.html
@@ -1,8 +1,8 @@
 {% macro share_scripts(g) -%}
   {% if not g.debug %}
-    <script type="text/javascript">var switchTo5x=true;</script>
-    <script type="text/javascript" src="http://w.sharethis.com/button/buttons.js"></script>
-    <script type="text/javascript" defer="defer">stLight.options({publisher: "ur-74a5b4dd-616a-419a-ba12-b7e5e84e437"}); </script>
+    <script src="https://apis.google.com/js/platform.js" async defer>
+      {lang: 'en-GB'}
+    </script>
   {% endif %}
 {%- endmacro %}
 
@@ -10,9 +10,29 @@
   {% if not g.debug %}
     <div class="row">
       <div class="span12">
-        <span class='st_twitter_hcount' displayText='Tweet'></span>
-        <span class='st_facebook_hcount' displayText='Facebook'></span>
-        <span class='st_plusone_hcount' displayText='Google +1'></span>
+        <!-- twitter share -->
+        <a href="https://twitter.com/share" class="twitter-share-button">Tweet</a>
+        <script>
+        !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');
+        </script>
+
+        <!-- facebook share -->
+        <script>
+        !function(d){
+          var currentEl=d.getElementsByTagName('script')[0];
+          var ifr=d.createElement('iframe');
+          ifr.src='https://www.facebook.com/plugins/share_button.php?href=' + encodeURIComponent(location.href) + '&layout=button_count';
+          ifr.setAttribute('scrolling', "no");
+          ifr.setAttribute('frameborder', "0");
+          ifr.setAttribute('allowtransparency', "true");
+          ifr.style.width = "110px";
+          ifr.style.height = "20px";
+          currentEl.parentNode.insertBefore(ifr,currentEl);
+        }(document);
+        </script>
+
+        <!-- g+ share -->
+        <div class="g-plusone" data-size="medium"></div>
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
Add social share buttons by coding ourself.
This change can revert when sharethis.com supports https delivery.
- [x] Check on Chrome
- [x] Check on Firefox
- [x] Check on Safari
- [x] Check on IE 11
- [x] Check on IE 10
