### PR TITLE
Fix box_url to vagrant box on vagrantcloud.com.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "trusty64"
-  config.vm.box_url = "https://vagrantcloud.com/ubuntu/trusty64/version/1/provider/virtualbox.box"
+  config.vm.box_url = "https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/14.04/providers/virtualbox.box"
   config.vm.hostname = "openspending"
 
   config.cache.auto_detect = true


### PR DESCRIPTION
I was getting a 404 error on the vagrant box so I replaced the `box_url` parameter with one that doesn't 404.

Before:

```
☁  openspending [master] vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'trusty64' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Adding box 'trusty64' (v0) for provider: virtualbox
    default: Downloading: https://vagrantcloud.com/ubuntu/trusty64/version/1/provider/virtualbox.box
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

The requested URL returned error: 404 Not Found
```

After:

```
☁  openspending [master] ⚡ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'trusty64' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Adding box 'trusty64' (v0) for provider: virtualbox
    default: Downloading: https://vagrantcloud.com/ubuntu/boxes/trusty64/versions/14.04/providers/virtualbox.box
    default: Progress: 11% (Rate: 300k/s, Estimated time remaining: 0:22:37)
```
